### PR TITLE
Fix typo error with setFriendRequests function

### DIFF
--- a/blisscord/src/components/FriendRequests.tsx
+++ b/blisscord/src/components/FriendRequests.tsx
@@ -64,7 +64,7 @@ const FriendRequests: FC<FriendRequestsProps> = ({
       id: senderId,
     });
 
-    setFriendRequest((prev) =>
+    setFriendRequests((prev) =>
       prev.filter((request) => request.senderId !== senderId),
     );
 


### PR DESCRIPTION
Type error: Cannot find name 'setFriendRequest'. Did you mean 'setFriendRequests'? Yes, yes I did.